### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,30 @@
+---
+name: "\U0001F41E Bug report "
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+###  Expected behavior
+A clear and concise description of what you expected to happen.
+
+###  Error log
+Error log, stack traceback, etc..
+
+###  Screenshots
+If applicable, add screenshots to help explain your problem.
+
+###  Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,41 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest an idea for improving MLModule
+title: ''
+labels: feature
+assignees: ''
+---
+
+### Is your proposal related to a problem?
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+(Write your answer here.)
+
+### Describe the solution you'd like
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+### Describe alternatives you've considered
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+(Write your answer here.)
+
+### Additional context
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+(Write your answer here.)

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -2,7 +2,7 @@
 name: "\U0001F680 Feature request"
 about: Suggest an idea for improving MLModule
 title: ''
-labels: feature
+labels: enhancement
 assignees: ''
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+Describe what changes you would like to add.
+
+## List of changes
+
+List all major changes.
+
+## Test plan
+
+If applicable, describe here how one can test your code
+
+## Associated GitHub Issues
+
+Link here any related issue, if possible using GitHub keywords.


### PR DESCRIPTION
## Description

This PR add GitHub templates for issues, for bugs and features, and for pull requests.
Templates are viewable under `.github/` folder and will go live when merged into the `master` branch.

Preview of _New Issue_ page (change _NewsTeller_ with _MLModule_):
![issues_screenshot](https://user-images.githubusercontent.com/41620979/167445359-dd4e9d69-1935-4ae9-83cc-b45320fb8cf1.png)

## List of changes

- new template for issues: bugs and features
- new template for pull requests

## Associated GitHub Issues

Closes #116 
