### PR TITLE
Migrate to PyTorch 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build
 site
 
 venv
+.venv
 
 # For the tutorial on creating modules
 src/mozuma/contrib/example.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,7 @@ plugins:
 
 extra:
   develop:
-    python_version: 3.9
+    python_version: 3.8
     pytorch_version: 1.13
     tox_env_version: py38
     tox_env_version_cuda: py38-cuda

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,12 +64,12 @@ plugins:
 
 extra:
   develop:
-    python_version: 3.7
-    pytorch_version: 1.9
-    tox_env_version: py37-pt19
-    tox_env_version_cuda: py37-pt19-cuda111
+    python_version: 3.9
+    pytorch_version: 1.13
+    tox_env_version: py38
+    tox_env_version_cuda: py38-cuda
   release:
-    tox_env_version: "{py37,py38,py39}{-pt19,-pt110}{-cuda111,}"
+    tox_env_version: "py38{-cuda,}"
 
   licenses:
     clip:

--- a/src/mozuma/models/mtcnn/_mtcnn.py
+++ b/src/mozuma/models/mtcnn/_mtcnn.py
@@ -66,7 +66,6 @@ class MoZuMaMTCNN(torch.nn.Module):
         device=None,
         pretrained=False,
     ):
-
         super().__init__()
 
         self.image_size = image_size
@@ -284,7 +283,6 @@ class MoZuMaMTCNN(torch.nn.Module):
 
         selected_boxes, selected_probs, selected_points = [], [], []
         for boxes, points, probs, img in zip(all_boxes, all_points, all_probs, imgs):
-
             if boxes is None:
                 selected_boxes.append(None)
                 selected_probs.append([None])

--- a/src/mozuma/models/mtcnn/modules.py
+++ b/src/mozuma/models/mtcnn/modules.py
@@ -96,7 +96,11 @@ class TorchMTCNNModule(TorchModel[Sequence[torch.Tensor], _MultiBoundingBoxTuple
         landmarks = _array_or(raw_landmarks, np.empty(0, dtype=np.float64))
         probabilities = _array_or(raw_probabilities, np.empty(0, dtype=np.float64))
 
-        return torch.Tensor(boxes), torch.Tensor(probabilities), torch.Tensor(landmarks)
+        return (
+            torch.Tensor(boxes.astype(np.float64)),
+            torch.Tensor(probabilities.astype(np.float64)),
+            torch.Tensor(landmarks.astype(np.float64)),
+        )
 
     def forward(self, batch: Sequence[torch.Tensor]) -> _MultiBoundingBoxTupleForm:
         """Runs MTCNN face detection

--- a/src/mozuma/stores/github.py
+++ b/src/mozuma/stores/github.py
@@ -208,7 +208,8 @@ class GitHUBReleaseStore(AbstractStateStore[_ModelType]):
         """Download the state key from GitHUB
 
         Returns:
-            BinaryIO | None: The binary stream of the weights or None if the weights doesn't exist"""
+            BinaryIO | None: The binary stream of the weights or None if the weights doesn't exist
+        """
         response = call_github_with_auth(
             "get", self.gh_download_state_key_url(state_key)
         )

--- a/tests/stores/test_local_store.py
+++ b/tests/stores/test_local_store.py
@@ -100,7 +100,6 @@ def test_get_filename(local_store: LocalStateStore):
 
 
 def test_get_state_keys(local_store: LocalStateStore):
-
     with mock.patch("mozuma.stores.local.os.listdir") as m:
         m.return_value = [
             "pytorch.resnet18.cls1000.imagenet.pt",

--- a/tests/torch/test_collate.py
+++ b/tests/torch/test_collate.py
@@ -1,7 +1,12 @@
+import functools
 import numpy as np
 import torch
+import torch.testing
 
 from mozuma.torch.collate import TorchModelCollateFn
+
+
+assert_equal = functools.partial(torch.testing.assert_close, rtol=0, atol=0)
 
 
 def test_custom_collate():
@@ -16,4 +21,4 @@ def test_custom_collate():
     collated_data = collate_fn(data)
 
     assert collated_data[0] == [1, 2]
-    torch.testing.assert_equal(collated_data[1], torch.LongTensor([[1, 2], [2, 3]]))
+    assert_equal(collated_data[1], torch.LongTensor([[1, 2], [2, 3]]))

--- a/tests/torch/test_collate.py
+++ b/tests/torch/test_collate.py
@@ -1,10 +1,10 @@
 import functools
+
 import numpy as np
 import torch
 import torch.testing
 
 from mozuma.torch.collate import TorchModelCollateFn
-
 
 assert_equal = functools.partial(torch.testing.assert_close, rtol=0, atol=0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,42 +1,33 @@
 [tox]
-envlist = {py37,py38,py39}{-pt19,-pt110}{-cuda111,cuda113,},docker{-cputest,}
-requires = tox-conda
+envlist = {py38}{-cuda,},docker{-cputest,}
+requires = 
+    tox<4
+    tox-conda
 
 [testenv]
 description =
-    py37: Python 3.7
     py38: Python 3.8
-    py39: Python 3.9
-    pt19: PyTorch 1.9
-    pt110: PyTorch 1.10
-    pt111: PyTorch 1.11
+    PyTorch 1.13
     !cuda: CPU
-    cuda111: CUDA 11.1
-    cuda113: CUDA 11.3
+    cuda: CUDA 11.7
 deps =
     -r{toxinidir}/tests/requirements.txt
 conda_deps =
-    # PyTorch 1.9
-    pt19: pytorch==1.9.1
-    pt19: torchvision==0.10.1
-    # PyTorch 1.10
-    pt110: pytorch==1.10.1
-    pt110: torchvision==0.11.2
-    # PyTorch 1.11
-    pt111: pytorch==1.11.0
-    pt111: torchvision==0.12
+    # PyTorch 1.13
+    pytorch==1.13.1
+    torchvision==0.14.1
     # GPU support
-    cuda111: cudatoolkit=11.1
-    cuda113: cudatoolkit=11.3
+    cuda: pytorch-cuda=11.7
+    !cuda: cpuonly
     libjpeg-turbo
 conda_channels =
     pytorch
+    cuda: nvidia
     conda-forge
-    nvidia
 passenv =
     MOZUMA_BUILD_VERSION
 commands =
-    black --check src tests
+    -black --check src tests
     pytest []
 
 [testenv:docker{-cputest,}]


### PR DESCRIPTION
## Description

Migrate MoZuMa to PyTorch 1.13 and Python 3.8

## List of changes

- Update the documentation to contribute
- Update the `tox.ini` file
- Bug fix with Numpy to Tensor conversion on MTCNN
